### PR TITLE
dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.env.test
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/env-sample
+++ b/env-sample
@@ -1,0 +1,2 @@
+ZILLOW_KEY =
+TRULIA_KEY =

--- a/sherlock_homes.gemspec
+++ b/sherlock_homes.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr"
+  spec.add_development_dependency 'dotenv'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'codeclimate-test-reporter'
 require 'dotenv'
 require 'rspec/given'
 require 'webmock/rspec'
@@ -9,6 +8,7 @@ require 'sherlock_homes'
 Dotenv.load('.env.test')
 
 if ENV['CODECLIMATE_REPO_TOKEN']
+  require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,16 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
+require 'codeclimate-test-reporter'
+require 'dotenv'
 require 'rspec/given'
 require 'webmock/rspec'
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'sherlock_homes'
+
+Dotenv.load('.env.test')
+
+if ENV['CODECLIMATE_REPO_TOKEN']
+  CodeClimate::TestReporter.start
+end
 
 support_files = Dir[File.join(
   File.expand_path('../../spec/support/**/*.rb', __FILE__)
@@ -13,7 +18,6 @@ support_files = Dir[File.join(
 support_files.each { |f| require f }
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = :random


### PR DESCRIPTION
During development we need a good way to manage configuration for 3rd party integration. In order to avoid using the repository to manage this variables I suggest to integrate `dotenv` as development gem and manage custom configuration into .env.test which rspec can load when launching the suite.