### PR TITLE
Cover property fields 1

### DIFF
--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -27,6 +27,12 @@ module SherlockHomes
 
     def map_property_details
       property.interior_features = raw_property.property_details[:interior_features]
+      property.property_information = raw_property.property_details[:property_information]
+      property.exterior_features = raw_property.property_details[:exterior_features]
+      property.homeowners_association_information = raw_property.property_details[:homeowners_association_information]
+      property.school_information = raw_property.property_details[:school_information]
+      property.utility_information = raw_property.property_details[:utility_information]
+      property.location_information = raw_property.property_details[:location_information]
       #TODO continue with other mappings
     end
 
@@ -51,6 +57,8 @@ module SherlockHomes
         room_information: [
           { attr: :total_rooms, regexp: /# of Rooms \(Total\):(.*)/ }
         ]
+        #TODO Lot Sq. Ft from lot_information
+        #TODO Sq. Ft. from property_features
       }
     end
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -17,7 +17,7 @@ module SherlockHomes
           items.each do |item|
             match_data = extractor[:regexp].match(item)
             if match_data
-              property.send("#{extractor[:attr]}=", match_data[1].strip)
+              property.send("#{extractor[:attr]}=", "#{match_data[1].strip}#{match_data[2]}")
               break
             end
           end
@@ -56,9 +56,13 @@ module SherlockHomes
         ],
         room_information: [
           { attr: :total_rooms, regexp: /# of Rooms \(Total\):(.*)/ }
+        ],
+        lot_information: [
+          { attr: :lot_sqft, regexp: /Lot Sq. Ft.:([^,]+),?([^,]+),?([^,]*)/ }
+        ],
+        property_features: [
+          { attr: :house_sqft, regexp: /Sq. Ft.:([^,]+),?([^,]+),?([^,]*)/ }
         ]
-        #TODO Lot Sq. Ft from lot_information
-        #TODO Sq. Ft. from property_features
       }
     end
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -32,6 +32,7 @@ module SherlockHomes
 
     def map_basic_info
       property.floors = raw_property.basic_info.floors.text
+      property.year_built = raw_property.basic_info.year_built.text
       #TODO continue with other mappings
     end
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -5,6 +5,7 @@ module SherlockHomes
       mapper = new(raw_property)
       mapper.map_property_details
       mapper.extract_from_property_details
+      mapper.map_basic_info
       # TODO invoke methods to map other groups of data
       mapper.property
     end
@@ -28,6 +29,12 @@ module SherlockHomes
       property.interior_features = raw_property.property_details[:interior_features]
       #TODO continue with other mappings
     end
+
+    def map_basic_info
+      property.floors = raw_property.basic_info.floors.text
+      #TODO continue with other mappings
+    end
+
 
     private
 

--- a/lib/sherlock_homes/mapper/trulia.rb
+++ b/lib/sherlock_homes/mapper/trulia.rb
@@ -9,6 +9,10 @@ module SherlockHomes
     end
 
     def map_public_records
+      stories = raw_property.public_records[:stories]
+      stories ||= raw_property.public_records[:story]
+      property.floors = /[[:digit:]]*/.match(stories).to_s.to_i
+
       bedrooms = raw_property.public_records[:bedrooms]
       bedrooms ||= raw_property.public_records[:bedroom]
       property.bedrooms = bedrooms

--- a/lib/sherlock_homes/mapper/trulia.rb
+++ b/lib/sherlock_homes/mapper/trulia.rb
@@ -9,6 +9,8 @@ module SherlockHomes
     end
 
     def map_public_records
+      property.year_built = raw_property.public_records[:built_in]
+
       stories = raw_property.public_records[:stories]
       stories ||= raw_property.public_records[:story]
       property.floors = /[[:digit:]]*/.match(stories).to_s.to_i

--- a/lib/sherlock_homes/mapper/trulia.rb
+++ b/lib/sherlock_homes/mapper/trulia.rb
@@ -10,6 +10,7 @@ module SherlockHomes
 
     def map_public_records
       property.year_built = raw_property.public_records[:built_in]
+      property.house_sqft = raw_property.public_records[:sqft].delete(',')
 
       stories = raw_property.public_records[:stories]
       stories ||= raw_property.public_records[:story]

--- a/lib/sherlock_homes/mapper/zillow.rb
+++ b/lib/sherlock_homes/mapper/zillow.rb
@@ -11,6 +11,8 @@ module SherlockHomes
     def map_basic_info
       property.property_type = raw_property.use_code
       property.year_built = raw_property.year_built
+      property.house_sqft = raw_property.finished_square_feet
+      property.lot_sqft = raw_property.lot_size_square_feet
       property.bedrooms = raw_property.bedrooms
       property.total_rooms = raw_property.total_rooms
     end

--- a/lib/sherlock_homes/mapper/zillow.rb
+++ b/lib/sherlock_homes/mapper/zillow.rb
@@ -10,6 +10,7 @@ module SherlockHomes
 
     def map_basic_info
       property.property_type = raw_property.use_code
+      property.year_built = raw_property.year_built
       property.bedrooms = raw_property.bedrooms
       property.total_rooms = raw_property.total_rooms
     end

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -5,6 +5,8 @@ module SherlockHomes
     attribute :property_type, String
     attribute :year_built, Integer
     attribute :floors, Integer
+    attribute :house_sqft, Integer
+    attribute :lot_sqft, Integer
     attribute :bedrooms, Integer
     attribute :full_bathrooms, Integer
     attribute :partial_bathrooms, Integer

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -9,7 +9,14 @@ module SherlockHomes
     attribute :full_bathrooms, Integer
     attribute :partial_bathrooms, Integer
     attribute :total_rooms, Integer
+
     attribute :interior_features, Array[String]
+    attribute :property_information, Array[String]
+    attribute :exterior_features, Array[String]
+    attribute :homeowners_association_information, Array[String]
+    attribute :school_information, Array[String]
+    attribute :utility_information, Array[String]
+    attribute :location_information, Array[String]
 
     # Keeps track of the source for each stored attribute.
     # Example: {bedrooms: 'redfin'}

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -3,6 +3,7 @@ module SherlockHomes
     include Virtus.model
 
     attribute :property_type, String
+    attribute :year_built, Integer
     attribute :floors, Integer
     attribute :bedrooms, Integer
     attribute :full_bathrooms, Integer

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -3,6 +3,7 @@ module SherlockHomes
     include Virtus.model
 
     attribute :property_type, String
+    attribute :floors, Integer
     attribute :bedrooms, Integer
     attribute :full_bathrooms, Integer
     attribute :partial_bathrooms, Integer

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -14,7 +14,7 @@ module SherlockHomes
       pick_from(source: :zillow, attributes: [:property_type, :year_built])
       pick_from(source: :redfin, attributes: [:interior_features])
       pick_from(source: :redfin, store_differences: true, attributes: [
-        :floors, :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms
+        :floors, :house_sqft, :lot_sqft, :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms
       ])
 
       #TODO to be continued ...

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -11,7 +11,7 @@ module SherlockHomes
     end
 
     def normalize
-      pick_from(source: :zillow, attributes: [:property_type])
+      pick_from(source: :zillow, attributes: [:property_type, :year_built])
       pick_from(source: :redfin, attributes: [:interior_features])
       pick_from(source: :redfin, store_differences: true, attributes: [
         :floors, :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -14,7 +14,7 @@ module SherlockHomes
       pick_from(source: :zillow, attributes: [:property_type])
       pick_from(source: :redfin, attributes: [:interior_features])
       pick_from(source: :redfin, store_differences: true, attributes: [
-        :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms
+        :floors, :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms
       ])
 
       #TODO to be continued ...

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
 
     Given(:raw_property) do
       double(
+        basic_info: double(
+          floors: double(text: '2')
+        ),
         property_details: {
           bedroom_information: [
             'Bedrooms: 4'
@@ -34,6 +37,7 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     When(:property) { subject.map(raw_property) }
 
     Then { property.is_a? SherlockHomes::Property }
+    And  { property.floors.eql? 2 }
     And  { property.bedrooms.eql? 4 }
     And  { property.full_bathrooms.eql? 2 }
     And  { property.partial_bathrooms.eql? 1 }

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
           ],
           lot_information: [
             'Private Road, Wooded',
-            '5 - 10 Acres'
+            '5 - 10 Acres',
+            'Lot Sq. Ft.: 328,878'
           ],
           property_features: [
             'Acres: 7.55',
@@ -71,6 +72,8 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     Then { property.is_a? SherlockHomes::Property }
     And  { property.year_built.eql? 1948 }
     And  { property.floors.eql? 2 }
+    And  { property.house_sqft.eql? 2969 }
+    And  { property.lot_sqft.eql? 328878 }
     And  { property.bedrooms.eql? 4 }
     And  { property.full_bathrooms.eql? 2 }
     And  { property.partial_bathrooms.eql? 1 }

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     Given(:raw_property) do
       double(
         basic_info: double(
-          floors: double(text: '2')
+          floors: double(text: '2'),
+          year_built: double(text: '1948')
         ),
         property_details: {
           bedroom_information: [
@@ -37,6 +38,7 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     When(:property) { subject.map(raw_property) }
 
     Then { property.is_a? SherlockHomes::Property }
+    And  { property.year_built.eql? 1948 }
     And  { property.floors.eql? 2 }
     And  { property.bedrooms.eql? 4 }
     And  { property.full_bathrooms.eql? 2 }

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -30,6 +30,37 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
             'Cooling: Zoned Cooling',
             'Fireplace Location: Family Room, Living Room',
             'Technology: Cable, Security System'
+          ],
+          lot_information: [
+            'Private Road, Wooded',
+            '5 - 10 Acres'
+          ],
+          property_features: [
+            'Acres: 7.55',
+            'Sq. Ft.: 2,969'
+          ],
+          property_information: [
+            'APN: 548580295557-1',
+            'Residential'
+          ],
+          exterior_features: [
+            'Roof: Slate',
+            'Patio, Porch'
+          ],
+          homeowners_association_information: [
+            'Condo HOA Fee: $0'
+          ],
+          school_information: [
+            'East Penn',
+            'High School: Emmaus'
+          ],
+          utility_information: [
+            'Water: Well',
+            'Sewer: Septic'
+          ],
+          location_information: [
+            'Lower Macungie',
+            'Zoning Code: S'
           ]
         }
       )
@@ -45,6 +76,12 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.partial_bathrooms.eql? 1 }
     And  { property.total_rooms.eql? 14 }
     And  { property.interior_features.eql? raw_property.property_details[:interior_features] }
+    And  { property.property_information.eql? raw_property.property_details[:property_information] }
+    And  { property.exterior_features.eql? raw_property.property_details[:exterior_features] }
+    And  { property.homeowners_association_information.eql? raw_property.property_details[:homeowners_association_information] }
+    And  { property.school_information.eql? raw_property.property_details[:school_information] }
+    And  { property.utility_information.eql? raw_property.property_details[:utility_information] }
+    And  { property.location_information.eql? raw_property.property_details[:location_information] }
 
   end
 end

--- a/spec/lib/mapper/trulia_spec.rb
+++ b/spec/lib/mapper/trulia_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
         public_records: {
           built_in: '1948',
           stories: '3 story with basement',
+          sqft: '2,563',
           bathrooms: '2',
           bathroom: '1 Partial',
           bedrooms: '3',
@@ -23,6 +24,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
 
     Then { property.is_a? SherlockHomes::Property }
     And  { property.year_built.eql? 1948 }
+    And  { property.house_sqft.eql? 2563 }
     And  { property.floors.eql? 3 }
     And  { property.bedrooms.eql? 3 }
     And  { property.full_bathrooms.eql? 2 }

--- a/spec/lib/mapper/trulia_spec.rb
+++ b/spec/lib/mapper/trulia_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
     Given(:raw_property) do
       double(
         public_records: {
+          stories: '3 story with basement',
           bathrooms: '2',
           bathroom: '1 Partial',
           bedrooms: '3',
@@ -20,6 +21,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
     When(:property) { subject.map(raw_property) }
 
     Then { property.is_a? SherlockHomes::Property }
+    And  { property.floors.eql? 3 }
     And  { property.bedrooms.eql? 3 }
     And  { property.full_bathrooms.eql? 2 }
     And  { property.partial_bathrooms.eql? 1 }

--- a/spec/lib/mapper/trulia_spec.rb
+++ b/spec/lib/mapper/trulia_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
     Given(:raw_property) do
       double(
         public_records: {
+          built_in: '1948',
           stories: '3 story with basement',
           bathrooms: '2',
           bathroom: '1 Partial',
@@ -21,6 +22,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
     When(:property) { subject.map(raw_property) }
 
     Then { property.is_a? SherlockHomes::Property }
+    And  { property.year_built.eql? 1948 }
     And  { property.floors.eql? 3 }
     And  { property.bedrooms.eql? 3 }
     And  { property.full_bathrooms.eql? 2 }

--- a/spec/lib/mapper/zillow_spec.rb
+++ b/spec/lib/mapper/zillow_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
       double(
         use_code: 'SingleFamily',
         year_built: '1948',
+        finished_square_feet: '3470',
+        lot_size_square_feet: '4680',
         bedrooms: '3',
         total_rooms: '5'
       )
@@ -20,6 +22,8 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
     Then { property.is_a? SherlockHomes::Property }
     And  { property.property_type.eql? 'SingleFamily' }
     And  { property.year_built.eql? 1948 }
+    And  { property.house_sqft.eql? 3470 }
+    And  { property.lot_sqft.eql? 4680 }
     And  { property.bedrooms.eql? 3 }
     And  { property.total_rooms.eql? 5 }
 

--- a/spec/lib/mapper/zillow_spec.rb
+++ b/spec/lib/mapper/zillow_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
     Given(:raw_property) do
       double(
         use_code: 'SingleFamily',
+        year_built: '1948',
         bedrooms: '3',
         total_rooms: '5'
       )
@@ -18,6 +19,7 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
 
     Then { property.is_a? SherlockHomes::Property }
     And  { property.property_type.eql? 'SingleFamily' }
+    And  { property.year_built.eql? 1948 }
     And  { property.bedrooms.eql? 3 }
     And  { property.total_rooms.eql? 5 }
 

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe SherlockHomes::Normalizer do
     Given(:redfin) do
       SherlockHomes::Property.new(
         year_built: 1948,
+        house_sqft: 2969,
+        lot_sqft: 328878,
         floors: 3,
         bedrooms: 4,
         partial_bathrooms: 2,
@@ -21,6 +23,8 @@ RSpec.describe SherlockHomes::Normalizer do
       SherlockHomes::Property.new(
         year_built: 1948,
         property_type: 'SingleFamily',
+        house_sqft: 2969,
+        lot_sqft: 155328,
         bedrooms: 3,
         total_rooms: 5
       )
@@ -30,6 +34,7 @@ RSpec.describe SherlockHomes::Normalizer do
       SherlockHomes::Property.new(
         year_built: 1948,
         floors: 3,
+        house_sqft: 2969,
         bedrooms: 3,
         partial_bathrooms: 1,
         full_bathrooms: 2,
@@ -53,9 +58,17 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.sources[:floors].eql? :redfin }
     And  { property.differences[:floors].nil? }
 
+    And  { property.house_sqft.eql? redfin.house_sqft }
+    And  { property.sources[:house_sqft].eql? :redfin }
+    And  { property.differences[:house_sqft].nil? }
+
     And  { property.bedrooms.eql? redfin.bedrooms }
     And  { property.sources[:bedrooms].eql? :redfin }
     And  { property.differences[:bedrooms].eql?({redfin: 4, zillow: 3, trulia: 3}) }
+
+    And  { property.lot_sqft.eql? redfin.lot_sqft }
+    And  { property.sources[:lot_sqft].eql? :redfin }
+    And  { property.differences[:lot_sqft].eql?({redfin: 328878, zillow: 155328, trulia: nil}) }
 
     And  { property.partial_bathrooms.eql? redfin.partial_bathrooms }
     And  { property.sources[:partial_bathrooms].eql? :redfin }

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SherlockHomes::Normalizer do
   describe '#normalize' do
     Given(:redfin) do
       SherlockHomes::Property.new(
+        year_built: 1948,
+        floors: 3,
         bedrooms: 4,
         partial_bathrooms: 2,
         full_bathrooms: 2,
@@ -17,6 +19,7 @@ RSpec.describe SherlockHomes::Normalizer do
 
     Given(:zillow) do
       SherlockHomes::Property.new(
+        year_built: 1948,
         property_type: 'SingleFamily',
         bedrooms: 3,
         total_rooms: 5
@@ -25,6 +28,8 @@ RSpec.describe SherlockHomes::Normalizer do
 
     Given(:trulia) do
       SherlockHomes::Property.new(
+        year_built: 1948,
+        floors: 3,
         bedrooms: 3,
         partial_bathrooms: 1,
         full_bathrooms: 2,
@@ -39,6 +44,14 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.property_type.eql? zillow.property_type }
     And  { property.sources[:property_type].eql? :zillow }
     And  { property.differences[:property_type].nil? }
+
+    And  { property.year_built.eql? zillow.year_built }
+    And  { property.sources[:year_built].eql? :zillow }
+    And  { property.differences[:year_built].nil? }
+
+    And  { property.floors.eql? redfin.floors }
+    And  { property.sources[:floors].eql? :redfin }
+    And  { property.differences[:floors].nil? }
 
     And  { property.bedrooms.eql? redfin.bedrooms }
     And  { property.sources[:bedrooms].eql? :redfin }

--- a/spec/lib/pipeline_spec.rb
+++ b/spec/lib/pipeline_spec.rb
@@ -9,9 +9,6 @@ RSpec.describe SherlockHomes::Pipeline, skip_ci: true do
   Given(:raw_location) { '2354 S Cedar Crest Blvd, Allentown, PA' }
   When(:ran_pipeline) { subject.run }
   Then { ran_pipeline.context.location.is_a? Geocoder::Result::Google }
-  And  { ran_pipeline.context.raw_zillow.is_a? Rubillow::Models::DeepSearchResult }
-  And  { ran_pipeline.context.raw_redfin.is_a? SherlockHomes::Scraper::Redfin }
-  And  { ran_pipeline.context.raw_trulia.is_a? SherlockHomes::Scraper::Trulia }
   And  { ran_pipeline.context.redfin.is_a? SherlockHomes::Property }
   And  { ran_pipeline.context.zillow.is_a? SherlockHomes::Property }
   And  { ran_pipeline.context.trulia.is_a? SherlockHomes::Property }

--- a/spec/lib/pipeline_spec.rb
+++ b/spec/lib/pipeline_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SherlockHomes::Pipeline, skip_ci: true do
     SherlockHomes::Pipeline.new(raw_location: raw_location)
   end
 
-  Given(:raw_location) { '2490 Riverbend Road, Allentown, PA' }
+  Given(:raw_location) { '2354 S Cedar Crest Blvd, Allentown, PA' }
   When(:ran_pipeline) { subject.run }
   Then { ran_pipeline.context.location.is_a? Geocoder::Result::Google }
   And  { ran_pipeline.context.raw_zillow.is_a? Rubillow::Models::DeepSearchResult }


### PR DESCRIPTION
Another chunk of Property fields mapped and normalized.

@jeffdeville The following needs attention

I decided to model 2 areas measured in square feet: 

1. lot size
2. house size - ignoring 'unfinished'

I'm picking those values from Redfin as they're more updated than public records, and I'm storing differences found on Zillow and Trulia (which both use public records)

![screen shot 2015-06-03 at 21 02 36](https://cloud.githubusercontent.com/assets/2955556/7968925/f09f68f6-0a33-11e5-95c3-de31015900b9.png)

1. lot size is "Lot Sq. Ft" in the "Lot Information" group
2. house size is "Sq. Ft." in the "Property Features" group
