### PR TITLE
Cover property fields 2

### DIFF
--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -3,8 +3,8 @@ module SherlockHomes
 
     def self.map(raw_property)
       mapper = new(raw_property)
-      mapper.map_property_details
       mapper.extract_from_property_details
+      mapper.map_property_details
       mapper.map_basic_info
       mapper.map_tax_info
       # TODO invoke methods to map other groups of data
@@ -34,6 +34,10 @@ module SherlockHomes
       property.school_information = raw_property.property_details[:school_information]
       property.utility_information = raw_property.property_details[:utility_information]
       property.location_information = raw_property.property_details[:location_information]
+
+      garage = raw_property.property_details[:garage]
+      property.parking_info += "; Garage: #{garage.join(', ')}" if garage
+
       #TODO continue with other mappings
     end
 
@@ -70,6 +74,10 @@ module SherlockHomes
         ],
         room_information: [
           { attr: :total_rooms, regexp: /# of Rooms \(Total\):(.*)/ }
+        ],
+        parking_information: [
+          { attr: :parking_ncars, regexp: /# of Cars:(.*)/ },
+          { attr: :parking_info, regexp: /Parking:(.*)/ }
         ],
         lot_information: [
           { attr: :lot_sqft, regexp: /Lot Sq. Ft.:([^,]+),?([^,]+),?([^,]*)/ }

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -7,6 +7,7 @@ module SherlockHomes
       mapper.map_property_details
       mapper.map_basic_info
       mapper.map_tax_info
+      mapper.map_summary_info
       mapper.map_neighborhood_info
       # TODO invoke methods to map other groups of data
       mapper.property
@@ -61,6 +62,12 @@ module SherlockHomes
       property.neighborhood_stats_chart = raw_property.neighborhood.stats_chart['src']
     end
 
+    def map_summary_info
+      property.description = raw_property.summary_info.description.text
+      property.style = raw_property.summary_info.style.text
+      property.view = raw_property.summary_info.view.text
+      property.community = raw_property.summary_info.community.text
+    end
 
     private
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -7,6 +7,7 @@ module SherlockHomes
       mapper.map_property_details
       mapper.map_basic_info
       mapper.map_tax_info
+      mapper.map_neighborhood_info
       # TODO invoke methods to map other groups of data
       mapper.property
     end
@@ -56,8 +57,8 @@ module SherlockHomes
     end
 
     def map_neighborhood_info
-      property.walk_score = neighborhood.walk_score.text
-      property.neighborhood_stats_chart = neighborhood.stats_chart['src']
+      property.walk_score = raw_property.neighborhood.walk_score.text
+      property.neighborhood_stats_chart = raw_property.neighborhood.stats_chart['src']
     end
 
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -51,6 +51,11 @@ module SherlockHomes
       property.taxes = digits_to_i.call(raw_property.tax_info.taxes.text)
     end
 
+    def map_neighborhood_info
+      property.walk_score = neighborhood.walk_score.text
+      property.neighborhood_stats_chart = neighborhood.stats_chart['src']
+    end
+
 
     private
 

--- a/lib/sherlock_homes/mapper/redfin.rb
+++ b/lib/sherlock_homes/mapper/redfin.rb
@@ -6,6 +6,7 @@ module SherlockHomes
       mapper.map_property_details
       mapper.extract_from_property_details
       mapper.map_basic_info
+      mapper.map_tax_info
       # TODO invoke methods to map other groups of data
       mapper.property
     end
@@ -40,6 +41,14 @@ module SherlockHomes
       property.floors = raw_property.basic_info.floors.text
       property.year_built = raw_property.basic_info.year_built.text
       #TODO continue with other mappings
+    end
+
+    def map_tax_info
+      digits_to_i = lambda { |s| s.gsub(/[^0-9]/, '').to_i }
+      property.taxable_land = digits_to_i.call(raw_property.tax_info.land.text)
+      property.taxable_additions = digits_to_i.call(raw_property.tax_info.additions.text)
+      property.taxable_total = digits_to_i.call(raw_property.tax_info.total.text)
+      property.taxes = digits_to_i.call(raw_property.tax_info.taxes.text)
     end
 
 

--- a/lib/sherlock_homes/mapper/trulia.rb
+++ b/lib/sherlock_homes/mapper/trulia.rb
@@ -3,35 +3,46 @@ module SherlockHomes
 
     def self.map(raw_property)
       mapper = new(raw_property)
-      mapper.map_public_records
+      mapper.map_features
       # TODO invoke methods to map other groups of data
       mapper.property
     end
 
-    def map_public_records
-      property.year_built = raw_property.public_records[:built_in]
-      property.house_sqft = raw_property.public_records[:sqft].delete(',')
+    def map_features
+      property.year_built = pick_feature([:built_in])
 
-      stories = raw_property.public_records[:stories]
-      stories ||= raw_property.public_records[:story]
-      property.floors = /[[:digit:]]*/.match(stories).to_s.to_i
+      sqft = pick_feature([:sqft])
+      property.house_sqft = sqft.delete(',') if sqft
 
-      bedrooms = raw_property.public_records[:bedrooms]
-      bedrooms ||= raw_property.public_records[:bedroom]
-      property.bedrooms = bedrooms
+      stories = pick_feature([:stories])
+      property.floors = /[[:digit:]]*/.match(stories).to_s.to_i if stories
 
-      rooms = raw_property.public_records[:rooms]
-      rooms ||= raw_property.public_records[:room]
-      property.total_rooms = rooms
+      property.bedrooms = pick_feature([:bedrooms, :bedroom])
+      property.total_rooms = pick_feature([:rooms, :room])
 
       map_bathroom_info
 
       #TODO to be continued ...
     end
 
+    private
+
+    # Search raw_property.features for keys in the order given.
+    # If an Array is found, returns the first element
+    def pick_feature(keys)
+      result = nil
+      keys.each do |key|
+        feature = raw_property.features[key]
+        next unless feature
+        result ||= feature.is_a?(Array) ? feature.first : feature
+        break if result
+      end
+      result
+    end
+
     def map_bathroom_info
       %i(bathrooms bathroom).each do |bath|
-        value = raw_property.public_records[bath]
+        value = pick_feature([bath])
         next if value.nil?
         match_data = /(.*)Partial/.match(value)
         if match_data

--- a/lib/sherlock_homes/mapper/zillow.rb
+++ b/lib/sherlock_homes/mapper/zillow.rb
@@ -4,6 +4,7 @@ module SherlockHomes
     def self.map(raw_property)
       mapper = new(raw_property)
       mapper.map_basic_info
+      mapper.map_estimate
       # TODO invoke methods to map other groups of data
       mapper.property
     end
@@ -15,6 +16,18 @@ module SherlockHomes
       property.lot_sqft = raw_property.lot_size_square_feet
       property.bedrooms = raw_property.bedrooms
       property.total_rooms = raw_property.total_rooms
+    end
+
+    def map_estimate
+      property.estimate = Property::Estimate.new(
+        last_updated: raw_property.last_updated,
+        value_change: raw_property.change,
+        value_change_duration: raw_property.change_duration,
+        valuation: raw_property.price,
+        valuation_range_low: raw_property.valuation_range[:low],
+        valuation_range_hi: raw_property.valuation_range[:high],
+        percentile: raw_property.percentile
+      )
     end
 
   end

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -2,6 +2,21 @@ module SherlockHomes
   class Property
     include Virtus.model
 
+    # Nested models
+
+    class Estimate
+      include Virtus.model
+
+      attribute :last_updated, Date
+      attribute :value_change, Integer
+      attribute :value_change_duration, Integer
+      attribute :valuation, Integer
+      attribute :valuation_range_low, Integer
+      attribute :valuation_range_hi, Integer
+      attribute :percentile, Integer
+    end
+
+
     # Keeps track of the source for each stored attribute.
     # Example: {bedrooms: 'redfin'}
     attribute :sources, Hash[Symbol => String]
@@ -41,5 +56,7 @@ module SherlockHomes
     attribute :parking_ncars, Integer
     attribute :parking_info, String
 
+    attribute :estimate, Estimate
   end
+
 end

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -37,6 +37,11 @@ module SherlockHomes
     attribute :partial_bathrooms, Integer
     attribute :total_rooms, Integer
 
+    attribute :description, String
+    attribute :style, String
+    attribute :view, String
+    attribute :community, String
+
     attribute :interior_features, Array[String]
     attribute :property_information, Array[String]
     attribute :exterior_features, Array[String]

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -38,5 +38,8 @@ module SherlockHomes
     attribute :walk_score, Integer
     attribute :neighborhood_stats_chart, String
 
+    attribute :parking_ncars, Integer
+    attribute :parking_info, String
+
   end
 end

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -20,6 +20,11 @@ module SherlockHomes
     attribute :utility_information, Array[String]
     attribute :location_information, Array[String]
 
+    attribute :taxable_land, Integer
+    attribute :taxable_additions, Integer
+    attribute :taxable_total, Integer
+    attribute :taxes, Integer
+
     # Keeps track of the source for each stored attribute.
     # Example: {bedrooms: 'redfin'}
     attribute :sources, Hash[Symbol => String]

--- a/lib/sherlock_homes/model/property.rb
+++ b/lib/sherlock_homes/model/property.rb
@@ -2,6 +2,16 @@ module SherlockHomes
   class Property
     include Virtus.model
 
+    # Keeps track of the source for each stored attribute.
+    # Example: {bedrooms: 'redfin'}
+    attribute :sources, Hash[Symbol => String]
+
+    # Keeps track of the differences for each stored attribute,
+    # found in sources different than the chosen one.
+    # Example: Assuming that bedrooms==2 and sources[:bedrooms]==:redfin, we could have
+    # differences == {bedrooms: {trulia: 1, zillow: 1}}
+    attribute :differences, Hash[Symbol => Hash]
+
     attribute :property_type, String
     attribute :year_built, Integer
     attribute :floors, Integer
@@ -25,15 +35,8 @@ module SherlockHomes
     attribute :taxable_total, Integer
     attribute :taxes, Integer
 
-    # Keeps track of the source for each stored attribute.
-    # Example: {bedrooms: 'redfin'}
-    attribute :sources, Hash[Symbol => String]
-
-    # Keeps track of the differences for each stored attribute,
-    # found in sources different than the chosen one.
-    # Example: Assuming that bedrooms==2 and sources[:bedrooms]==:redfin, we could have
-    # differences == {bedrooms: {trulia: 1, zillow: 1}}
-    attribute :differences, Hash[Symbol => Hash]
+    attribute :walk_score, Integer
+    attribute :neighborhood_stats_chart, String
 
   end
 end

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -17,7 +17,8 @@ module SherlockHomes
         :interior_features, :property_information, :exterior_features,
         :homeowners_association_information, :school_information, :utility_information,
         :location_information, :taxable_land, :taxable_additions, :taxable_total,
-        :taxes, :walk_score, :neighborhood_stats_chart, :parking_ncars, :parking_info
+        :taxes, :walk_score, :neighborhood_stats_chart, :parking_ncars, :parking_info,
+        :description, :style, :view, :community
       ])
 
       pick_from(source: :redfin, store_differences: true, attributes: [

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -17,7 +17,7 @@ module SherlockHomes
         :interior_features, :property_information, :exterior_features,
         :homeowners_association_information, :school_information, :utility_information,
         :location_information, :taxable_land, :taxable_additions, :taxable_total,
-        :taxes, :walk_score, :neighborhood_stats_chart
+        :taxes, :walk_score, :neighborhood_stats_chart, :parking_ncars, :parking_info
       ])
 
       pick_from(source: :redfin, store_differences: true, attributes: [

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -17,7 +17,7 @@ module SherlockHomes
         :interior_features, :property_information, :exterior_features,
         :homeowners_association_information, :school_information, :utility_information,
         :location_information, :taxable_land, :taxable_additions, :taxable_total,
-        :taxes
+        :taxes, :walk_score, :neighborhood_stats_chart
       ])
 
       pick_from(source: :redfin, store_differences: true, attributes: [

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -16,7 +16,8 @@ module SherlockHomes
       pick_from(source: :redfin, attributes: [
         :interior_features, :property_information, :exterior_features,
         :homeowners_association_information, :school_information, :utility_information,
-        :location_information
+        :location_information, :taxable_land, :taxable_additions, :taxable_total,
+        :taxes
       ])
 
       pick_from(source: :redfin, store_differences: true, attributes: [

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -12,7 +12,13 @@ module SherlockHomes
 
     def normalize
       pick_from(source: :zillow, attributes: [:property_type, :year_built])
-      pick_from(source: :redfin, attributes: [:interior_features])
+
+      pick_from(source: :redfin, attributes: [
+        :interior_features, :property_information, :exterior_features,
+        :homeowners_association_information, :school_information, :utility_information,
+        :location_information
+      ])
+
       pick_from(source: :redfin, store_differences: true, attributes: [
         :floors, :house_sqft, :lot_sqft, :bedrooms, :partial_bathrooms, :full_bathrooms, :total_rooms
       ])

--- a/lib/sherlock_homes/normalizer.rb
+++ b/lib/sherlock_homes/normalizer.rb
@@ -11,7 +11,7 @@ module SherlockHomes
     end
 
     def normalize
-      pick_from(source: :zillow, attributes: [:property_type, :year_built])
+      pick_from(source: :zillow, attributes: [:property_type, :year_built, :estimate])
 
       pick_from(source: :redfin, attributes: [
         :interior_features, :property_information, :exterior_features,

--- a/lib/sherlock_homes/scraper/redfin.rb
+++ b/lib/sherlock_homes/scraper/redfin.rb
@@ -27,6 +27,16 @@ module SherlockHomes
       return "https://www.redfin.com#{search_results[0]['URL']}"
     end
 
+    class SummaryInfo < SitePrism::Section
+      element :description, 'span[data-reactid=".0.0.1.2.1.0.2.0.1"]'
+      element :style, 'td[data-reactid=".0.0.1.2.1.0.3.0.0.1.1"]'
+      element :view, 'td[data-reactid=".0.0.1.2.1.0.3.0.0.2.1"]'
+      element :county, 'td[data-reactid=".0.0.1.2.1.0.3.0.0.3.1"]'
+      element :property_type, 'td[data-reactid=".0.0.1.2.1.0.3.1.0.0.1"]'
+      element :community, 'td[data-reactid=".0.0.1.2.1.0.3.1.0.2.1"]'
+      element :mls, 'td[data-reactid=".0.0.1.2.1.0.3.1.0.3.1"]'
+    end
+
     class BasicInfo < SitePrism::Section
       element :bed, 'table:nth-child(1) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)'
 
@@ -85,8 +95,7 @@ module SherlockHomes
 
     element :contact_box, '#redfin_common_widgets_contactBox_ContactBoxHTML_4'
 
-    element :description, '.remarks > p:nth-child(1) > span:nth-child(1)'
-
+    section :summary_info, SummaryInfo, 'div[data-reactid=".0.0.1.2.1"]'
     section :neighborhood, Neighborhood, 'div[data-dojo-attach-point=neighborhoodPanelContainer] div[data-dojo-attach-point=mainContent]'
     section  :basic_info, BasicInfo, 'div[data-dojo-attach-point=publicRecordsPanelContainer] > div.basic-info > div:nth-child(2)'
     section  :tax_info, TaxInfo, 'div[data-dojo-attach-point=publicRecordsPanelContainer] > div.taxable-value > div:nth-child(2) > table:nth-child(1) > tbody:nth-child(1)'

--- a/lib/sherlock_homes/scraper/trulia.rb
+++ b/lib/sherlock_homes/scraper/trulia.rb
@@ -53,10 +53,10 @@ module SherlockHomes
 
     sections :taxes_assessments, TaxesAssessments, 'body > section > div:nth-child(1) > div > div:nth-child(5) > div > div.mtl > table > tbody > tr'
 
-    def public_records
-      @public_records ||= Hash.new.tap do |result|
+    def features
+      @features ||= Hash.new.tap do |result|
         all('div.mtl ul.listBulleted > li').each do |pr|
-          result.merge! parse(pr.text) {|key, oldval, newval| [oldval, newval].flatten}
+          result.merge!(parse(pr.text)) {|key, oldval, newval| [oldval, newval].flatten}
         end
       end
     end
@@ -64,13 +64,13 @@ module SherlockHomes
     private
 
     def parse(data)
-      key = 'unknown'
+      key = nil
       value = nil
       sep = ':'
 
       patterns = [
         'bathrooms', 'bathroom', 'bedrooms', 'bedroom', 'rooms', 'room',
-        'built in', 'sqft', 'fireplace', 'units', 'unit'
+        'built in', 'sqft', 'units', 'unit'
       ]
 
       if data.include? sep
@@ -86,10 +86,11 @@ module SherlockHomes
             break
           end
         end
+        rand_number = ('0'..'9').to_a.shuffle[0,5].join
+        key ||= "unknown_#{rand_number}"
         value ||= data
       end
-      key.gsub!(/[^\w]/, '_')
-      { key.titleize.delete(' ').underscore.to_sym => value }
+      { key.gsub(/[^\w]/, '_').to_sym => value }
     end
 
   end

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -63,7 +63,13 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
             'Lower Macungie',
             'Zoning Code: S'
           ]
-        }
+        },
+        tax_info: double(
+          land: double(text: '$102,400'),
+          additions: double(text: '$265,100'),
+          total: double(text: '$367,500'),
+          taxes: double(text: '$7,624')
+        )
       )
     end
 
@@ -78,6 +84,7 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.full_bathrooms.eql? 2 }
     And  { property.partial_bathrooms.eql? 1 }
     And  { property.total_rooms.eql? 14 }
+
     And  { property.interior_features.eql? raw_property.property_details[:interior_features] }
     And  { property.property_information.eql? raw_property.property_details[:property_information] }
     And  { property.exterior_features.eql? raw_property.property_details[:exterior_features] }
@@ -85,6 +92,11 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.school_information.eql? raw_property.property_details[:school_information] }
     And  { property.utility_information.eql? raw_property.property_details[:utility_information] }
     And  { property.location_information.eql? raw_property.property_details[:location_information] }
+
+    And  { property.taxable_land.eql? 102400 }
+    And  { property.taxable_additions.eql? 265100 }
+    And  { property.taxable_total.eql? 367500 }
+    And  { property.taxes.eql? 7624 }
 
   end
 end

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
             'Dining Room',
             'Daylight, Partially Finished'
           ],
+          parking_information: [
+            '# of Cars: 2',
+            'Parking: Off Street'
+          ],
+          garage: [
+            'Built-In'
+          ],
           interior_features: [
             'Cooling: Zoned Cooling',
             'Fireplace Location: Family Room, Living Room',
@@ -101,6 +108,9 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.taxable_additions.eql? 265100 }
     And  { property.taxable_total.eql? 367500 }
     And  { property.taxes.eql? 7624 }
+
+    And  { property.parking_ncars.eql? 2 }
+    And  { property.parking_info.eql? 'Off Street; Garage: Built-In' }
 
   end
 end

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
 
     Given(:raw_property) do
       double(
+        summary_info: double(
+          description: double(text: 'A lovely classic estate home'),
+          style: double(text: 'Colonial, Traditional'),
+          view: double(text: 'Hills'),
+          community: double(text: 'Lower Macungie Twp')
+        ),
         basic_info: double(
           floors: double(text: '2'),
           year_built: double(text: '1948')
@@ -95,6 +101,11 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.full_bathrooms.eql? 2 }
     And  { property.partial_bathrooms.eql? 1 }
     And  { property.total_rooms.eql? 14 }
+
+    And  { property.description.eql? raw_property.summary_info.description.text }
+    And  { property.style.eql? raw_property.summary_info.style.text }
+    And  { property.view.eql? raw_property.summary_info.view.text }
+    And  { property.community.eql? raw_property.summary_info.community.text }
 
     And  { property.interior_features.eql? raw_property.property_details[:interior_features] }
     And  { property.property_information.eql? raw_property.property_details[:property_information] }

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -109,6 +109,9 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
     And  { property.taxable_total.eql? 367500 }
     And  { property.taxes.eql? 7624 }
 
+    And  { property.walk_score.eql? 2 }
+    And  { property.neighborhood_stats_chart.eql? raw_property.neighborhood.stats_chart['src'] }
+
     And  { property.parking_ncars.eql? 2 }
     And  { property.parking_info.eql? 'Off Street; Garage: Built-In' }
 

--- a/spec/lib/mapper/redfin_spec.rb
+++ b/spec/lib/mapper/redfin_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe SherlockHomes::Mapper::Redfin do
           additions: double(text: '$265,100'),
           total: double(text: '$367,500'),
           taxes: double(text: '$7,624')
+        ),
+        neighborhood: double(
+          walk_score: double(text: '2'),
+          stats_chart: {'src' => '2/6989/MEDIAN_HOUSE_SQ_FT_BY_TIME.png'}
         )
       )
     end

--- a/spec/lib/mapper/trulia_spec.rb
+++ b/spec/lib/mapper/trulia_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SherlockHomes::Mapper::Trulia do
 
     Given(:raw_property) do
       double(
-        public_records: {
+        features: {
           built_in: '1948',
           stories: '3 story with basement',
           sqft: '2,563',

--- a/spec/lib/mapper/zillow_spec.rb
+++ b/spec/lib/mapper/zillow_spec.rb
@@ -13,7 +13,17 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
         finished_square_feet: '3470',
         lot_size_square_feet: '4680',
         bedrooms: '3',
-        total_rooms: '5'
+        total_rooms: '5',
+
+        last_updated: Date.today,
+        change: "-7187",
+        change_duration: "30",
+        price: "1379674",
+        valuation_range: {
+          low: "1283097",
+          high: "1462454",
+        },
+        percentile: "0"
       )
     end
 
@@ -27,5 +37,13 @@ RSpec.describe SherlockHomes::Mapper::Zillow do
     And  { property.bedrooms.eql? 3 }
     And  { property.total_rooms.eql? 5 }
 
+    And  { property.estimate.is_a? SherlockHomes::Property::Estimate }
+    And  { property.estimate.last_updated.eql? raw_property.last_updated }
+    And  { property.estimate.value_change.eql? raw_property.change.to_i }
+    And  { property.estimate.value_change_duration.eql? raw_property.change_duration.to_i }
+    And  { property.estimate.valuation.eql? raw_property.price.to_i }
+    And  { property.estimate.percentile.eql? raw_property.percentile.to_i }
+    And  { property.estimate.valuation_range_low.eql? raw_property.valuation_range[:low].to_i }
+    And  { property.estimate.valuation_range_hi.eql? raw_property.valuation_range[:high].to_i }
   end
 end

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe SherlockHomes::Normalizer do
         taxable_land: 102400,
         taxable_additions: 265100,
         taxable_total: 367500,
-        taxes: 7624
+        taxes: 7624,
+
+        walk_score: 2,
+        neighborhood_stats_chart: '2/6989/MEDIAN_HOUSE_SQ_FT_BY_TIME.png'
       )
     end
 
@@ -166,6 +169,14 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.taxes.eql? redfin.taxes }
     And  { property.sources[:taxes].eql? :redfin }
     And  { property.differences[:taxes].nil? }
+
+    And  { property.walk_score.eql? redfin.walk_score }
+    And  { property.sources[:walk_score].eql? :redfin }
+    And  { property.differences[:walk_score].nil? }
+
+    And  { property.neighborhood_stats_chart.eql? redfin.neighborhood_stats_chart }
+    And  { property.sources[:neighborhood_stats_chart].eql? :redfin }
+    And  { property.differences[:neighborhood_stats_chart].nil? }
 
   end
 

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe SherlockHomes::Normalizer do
         house_sqft: 2969,
         lot_sqft: 155328,
         bedrooms: 3,
-        total_rooms: 5
+        total_rooms: 5,
+        estimate: SherlockHomes::Property::Estimate.new
       )
     end
 
@@ -92,6 +93,10 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.year_built.eql? zillow.year_built }
     And  { property.sources[:year_built].eql? :zillow }
     And  { property.differences[:year_built].nil? }
+
+    And  { property.estimate.eql? zillow.estimate }
+    And  { property.sources[:estimate].eql? :zillow }
+    And  { property.differences[:estimate].nil? }
 
     And  { property.floors.eql? redfin.floors }
     And  { property.sources[:floors].eql? :redfin }

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe SherlockHomes::Normalizer do
         taxes: 7624,
 
         walk_score: 2,
-        neighborhood_stats_chart: '2/6989/MEDIAN_HOUSE_SQ_FT_BY_TIME.png'
+        neighborhood_stats_chart: '2/6989/MEDIAN_HOUSE_SQ_FT_BY_TIME.png',
+
+        parking_ncars: 2,
+        parking_info: 'Off Street; Garage: Built-In'
       )
     end
 
@@ -177,6 +180,14 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.neighborhood_stats_chart.eql? redfin.neighborhood_stats_chart }
     And  { property.sources[:neighborhood_stats_chart].eql? :redfin }
     And  { property.differences[:neighborhood_stats_chart].nil? }
+
+    And  { property.parking_ncars.eql? redfin.parking_ncars }
+    And  { property.sources[:parking_ncars].eql? :redfin }
+    And  { property.differences[:parking_ncars].nil? }
+
+    And  { property.parking_info.eql? redfin.parking_info }
+    And  { property.sources[:parking_info].eql? :redfin }
+    And  { property.differences[:parking_info].nil? }
 
   end
 

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -14,8 +14,36 @@ RSpec.describe SherlockHomes::Normalizer do
         bedrooms: 4,
         partial_bathrooms: 2,
         full_bathrooms: 2,
-        interior_features: %w(Fireplace Cooling),
-        total_rooms: 6
+        total_rooms: 6,
+
+        interior_features: [
+          'Cooling: Zoned Cooling',
+          'Fireplace Location: Family Room, Living Room',
+          'Technology: Cable, Security System'
+        ],
+        property_information: [
+          'APN: 548580295557-1',
+          'Residential'
+        ],
+        exterior_features: [
+          'Roof: Slate',
+          'Patio, Porch'
+        ],
+        homeowners_association_information: [
+          'Condo HOA Fee: $0'
+        ],
+        school_information: [
+          'East Penn',
+          'High School: Emmaus'
+        ],
+        utility_information: [
+          'Water: Well',
+          'Sewer: Septic'
+        ],
+        location_information: [
+          'Lower Macungie',
+          'Zoning Code: S'
+        ]
       )
     end
 
@@ -85,6 +113,38 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.interior_features.eql? redfin.interior_features }
     And  { property.sources[:interior_features].eql? :redfin }
     And  { property.differences[:interior_features].nil? }
+
+    And  { property.interior_features.eql? redfin.interior_features }
+    And  { property.sources[:interior_features].eql? :redfin }
+    And  { property.differences[:interior_features].nil? }
+
+    And  { property.interior_features.eql? redfin.interior_features }
+    And  { property.sources[:interior_features].eql? :redfin }
+    And  { property.differences[:interior_features].nil? }
+
+    And  { property.property_information.eql? redfin.property_information }
+    And  { property.sources[:property_information].eql? :redfin }
+    And  { property.differences[:property_information].nil? }
+
+    And  { property.exterior_features.eql? redfin.exterior_features }
+    And  { property.sources[:exterior_features].eql? :redfin }
+    And  { property.differences[:exterior_features].nil? }
+
+    And  { property.homeowners_association_information.eql? redfin.homeowners_association_information }
+    And  { property.sources[:homeowners_association_information].eql? :redfin }
+    And  { property.differences[:homeowners_association_information].nil? }
+
+    And  { property.school_information.eql? redfin.school_information }
+    And  { property.sources[:school_information].eql? :redfin }
+    And  { property.differences[:school_information].nil? }
+
+    And  { property.utility_information.eql? redfin.utility_information }
+    And  { property.sources[:utility_information].eql? :redfin }
+    And  { property.differences[:utility_information].nil? }
+
+    And  { property.location_information.eql? redfin.location_information }
+    And  { property.sources[:location_information].eql? :redfin }
+    And  { property.differences[:location_information].nil? }
 
   end
 

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -43,7 +43,12 @@ RSpec.describe SherlockHomes::Normalizer do
         location_information: [
           'Lower Macungie',
           'Zoning Code: S'
-        ]
+        ],
+
+        taxable_land: 102400,
+        taxable_additions: 265100,
+        taxable_total: 367500,
+        taxes: 7624
       )
     end
 
@@ -145,6 +150,22 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.location_information.eql? redfin.location_information }
     And  { property.sources[:location_information].eql? :redfin }
     And  { property.differences[:location_information].nil? }
+
+    And  { property.taxable_land.eql? redfin.taxable_land }
+    And  { property.sources[:taxable_land].eql? :redfin }
+    And  { property.differences[:taxable_land].nil? }
+
+    And  { property.taxable_additions.eql? redfin.taxable_additions }
+    And  { property.sources[:taxable_additions].eql? :redfin }
+    And  { property.differences[:taxable_additions].nil? }
+
+    And  { property.taxable_total.eql? redfin.taxable_total }
+    And  { property.sources[:taxable_total].eql? :redfin }
+    And  { property.differences[:taxable_total].nil? }
+
+    And  { property.taxes.eql? redfin.taxes }
+    And  { property.sources[:taxes].eql? :redfin }
+    And  { property.differences[:taxes].nil? }
 
   end
 

--- a/spec/lib/normalizer_spec.rb
+++ b/spec/lib/normalizer_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe SherlockHomes::Normalizer do
         full_bathrooms: 2,
         total_rooms: 6,
 
+        description: 'A lovely classic estate home',
+        style: 'Colonial, Traditional',
+        view: 'Hills',
+        community: 'Lower Macungie Twp',
+
         interior_features: [
           'Cooling: Zoned Cooling',
           'Fireplace Location: Family Room, Living Room',
@@ -126,9 +131,21 @@ RSpec.describe SherlockHomes::Normalizer do
     And  { property.sources[:total_rooms].eql? :redfin }
     And  { property.differences[:total_rooms].eql?({redfin: 6, zillow: 5, trulia: 5}) }
 
-    And  { property.interior_features.eql? redfin.interior_features }
-    And  { property.sources[:interior_features].eql? :redfin }
-    And  { property.differences[:interior_features].nil? }
+    And  { property.description.eql? redfin.description }
+    And  { property.sources[:description].eql? :redfin }
+    And  { property.differences[:description].nil? }
+
+    And  { property.style.eql? redfin.style }
+    And  { property.sources[:style].eql? :redfin }
+    And  { property.differences[:style].nil? }
+
+    And  { property.view.eql? redfin.view }
+    And  { property.sources[:view].eql? :redfin }
+    And  { property.differences[:view].nil? }
+
+    And  { property.community.eql? redfin.community }
+    And  { property.sources[:community].eql? :redfin }
+    And  { property.differences[:community].nil? }
 
     And  { property.interior_features.eql? redfin.interior_features }
     And  { property.sources[:interior_features].eql? :redfin }

--- a/spec/lib/scraper/redfin_spec.rb
+++ b/spec/lib/scraper/redfin_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe SherlockHomes::Scraper::Redfin, skip_ci: true do
     describe 'main info' do
       Then { subject.title.eql?('2354 S Cedar Crest Blvd, Lower Macungie Twp, PA 18103 | MLS# 486144 | Redfin') }
 
-      # Description
-      And { expect(subject.description.text).to_not be_nil }
+      # Summary Info
+      And { expect(subject.summary_info.description.text).to include('A lovely classic estate home') }
+      And { expect(subject.summary_info.style.text).to be_eql('Colonial, Traditional') }
+      And { expect(subject.summary_info.view.text).to be_eql('Hills') }
+      And { expect(subject.summary_info.county.text).to be_eql('Lehigh') }
+      And { expect(subject.summary_info.property_type.text).to be_eql('Residential') }
+      And { expect(subject.summary_info.community.text).to be_eql('Lower Macungie Twp') }
+      And { expect(subject.summary_info.mls.text).to be_eql('486144') }
 
       # Basic Info
       And  { expect(subject.basic_info.bed.text).to be_eql('4') }

--- a/spec/lib/scraper/trulia_spec.rb
+++ b/spec/lib/scraper/trulia_spec.rb
@@ -11,24 +11,23 @@ RSpec.describe SherlockHomes::Scraper::Trulia, skip_ci: true do
   And  { subject.image['src'].include?('2490-Riverbend-Rd-Allentown-PA-18103.jpg') }
 
   # Public Records
-  And  { subject.public_records.is_a? Hash }
-  And  { subject.public_records[:bathroom].eql? '1 Partial' }
-  And  { subject.public_records[:built_in].eql? '1875' }
-  And  { subject.public_records[:heating].eql? 'Central' }
-  And  { subject.public_records[:exterior_walls].eql? 'Brick' }
-  And  { subject.public_records[:basement].eql? 'Full Basement' }
-  And  { subject.public_records[:bedrooms].eql? '3' }
-  And  { subject.public_records[:sqft].eql? '2,563' }
-  And  { subject.public_records[:stories].eql? '3 story with basement' }
-  And  { subject.public_records[:parking].eql? 'Detached Garage' }
-  And  { subject.public_records[:rooms].eql? '8' }
-  And  { subject.public_records[:fireplace].eql? '' }
-  And  { subject.public_records[:bathrooms].eql? '2' }
-  And  { subject.public_records[:lot_size].eql? '0.9 acres' }
-  And  { subject.public_records[:ac].eql? 'Central' }
-  And  { subject.public_records[:parking_spaces].eql? '2' }
-  And  { subject.public_records[:unit].eql? '1' }
-  And  { subject.public_records[:county].eql? 'Lehigh' }
+  And  { subject.features.is_a? Hash }
+  And  { subject.features[:bathroom].eql? '1 Partial' }
+  And  { subject.features[:built_in].eql? '1875' }
+  And  { subject.features[:heating].eql? 'Central' }
+  And  { subject.features[:exterior_walls].eql? 'Brick' }
+  And  { subject.features[:basement].eql? 'Full Basement' }
+  And  { subject.features[:bedrooms].eql? '3' }
+  And  { subject.features[:sqft].eql? '2,563' }
+  And  { subject.features[:stories].eql? '3 story with basement' }
+  And  { subject.features[:parking].eql? 'Detached Garage' }
+  And  { subject.features[:rooms].eql? '8' }
+  And  { subject.features[:bathrooms].eql? '2' }
+  And  { subject.features[:lot_size].eql? '0.9 acres' }
+  And  { subject.features[:a_c].eql? 'Central' }
+  And  { subject.features[:parking_spaces].eql? '2' }
+  And  { subject.features[:unit].eql? '1' }
+  And  { subject.features[:county].eql? 'Lehigh' }
 
   # Taxes and Assessment
   And  { subject.taxes_assessments.is_a? Array }


### PR DESCRIPTION
@jeffdeville The following items need your review.


## Tax Info

The following fields

 + taxable_land
 + taxable_additions
 + taxable_total
 + taxes
 
are picked from Redfin (example [here](https://www.redfin.com/PA/Allentown/2354-S-Cedar-Crest-Blvd-18103/home/59034427)) and come from Public Records.

![screen shot 2015-06-05 at 17 02 32](https://cloud.githubusercontent.com/assets/2955556/8008801/b11640de-0ba4-11e5-8315-a89148ff8f17.png)

But Redfin also reports other tax info in the Property Details section, perhaps those are more up-to-date? In that case we could grab additional fields/values from "Assessments" and "Tax Information" groups

![screen shot 2015-06-05 at 11 43 51](https://cloud.githubusercontent.com/assets/2955556/8008821/cb0ed9d8-0ba4-11e5-97e8-09e2a62a8845.png)

---

## Parking Data

I'm picking them from Redfin as I really can't understand how to combine them with Trulia, neither how to report differences. For the same house, on [Redfin](https://www.redfin.com/PA/Allentown/2354-S-Cedar-Crest-Blvd-18103/home/59034427) I see the following:

![screen shot 2015-06-05 at 16 23 16](https://cloud.githubusercontent.com/assets/2955556/8008850/f6fe1ef0-0ba4-11e5-9a48-eef8ffa58159.png)

whereas on [Trulia](http://www.trulia.com/property/3135277075-2354-S-Cedar-Crest-Blvd-Allentown-PA-18103) I see:

**Features** section:

 + Parking: other
 + Parking Spaces: Off Street
 
**Public Records** section:

 + Parking: Attached Garage
 + Parking Spaces: 2

so I really don't know how to map/combine. Any suggestion?